### PR TITLE
Bug fix: Inconsistent breakpoint setting if `tab_size` isn't been specified

### DIFF
--- a/PythonBreakpoints.py
+++ b/PythonBreakpoints.py
@@ -21,7 +21,7 @@ import sublime_plugin
 settings = sublime.load_settings("PythonBreakpoints.sublime-settings")
 
 tab_size = settings.get('tab_size')
-if tab_size == 'auto':
+if tab_size == 'auto' or tab_size == None:
     g_settings = sublime.load_settings('Preferences.sublime-settings')
     tab_size = g_settings.get('tab_size', 4)
 


### PR DESCRIPTION
For whatever reason, cloning the Package from GitHub left `tab_size` not specified until I opened and saved the settings file. It's happened before (perhaps due to installing while ST is running), but to get things working OK out of the box it required either:
1. Adding `.. or tab_size == None` to the default behaviour clause, **or**
2. Opening and saving the settings

I don't know what I've done, but it was reproducible at work and home. :confused: 
