### PR TITLE
OS X shortcut for goto_breakpoint conflicts with Find Next.

### DIFF
--- a/Default (OSX).sublime-keymap
+++ b/Default (OSX).sublime-keymap
@@ -3,5 +3,5 @@
 
   { "keys": ["ctrl+shift+b"], "command": "toggle_breakpoint" },
 
-  { "keys": ["super+g"], "command": "goto_breakpoint" }
+  { "keys": ["ctrl+shift+g"], "command": "goto_breakpoint" }
 ]


### PR DESCRIPTION
The shortcut key combo for `Find -> Find Next` is `super+g`, Python Breakpoint overwrites that.

Changing the key combo for `goto_breakpoint` in my `Default (OSX).sublime-keymap` file correctly changed the combo, but `super+g` still failed to function.
