### PR TITLE
ability to breakpoint with any 1 liner

### DIFF
--- a/PythonBreakpoints.py
+++ b/PythonBreakpoints.py
@@ -87,6 +87,10 @@ class Breakpoint(object):
         format breakpoint string
         """
         debugger = settings.get('debugger', 'pdb')
+        custom_string = settings.get('breakpoint_string', 'pdb')
+        if not debugger and breakpoint_string:
+            return "{breakpoint_string}  # breakpoint {uid}{mark} noqa  //\n".format(
+            breakpoint_string=custom_string, uid=self.uid, mark='x' if self.in_block else '')
         return "{indent}import {dbg}; {dbg}.set_trace()  # breakpoint {uid}{mark} //\n".format(
             indent=' ' * indent, dbg=debugger, uid=self.uid, mark='x' if self.in_block else '')
 

--- a/PythonBreakpoints.py
+++ b/PythonBreakpoints.py
@@ -87,10 +87,10 @@ class Breakpoint(object):
         format breakpoint string
         """
         debugger = settings.get('debugger', 'pdb')
-        custom_string = settings.get('breakpoint_string', 'pdb')
-        if not debugger and breakpoint_string:
+        custom_string = settings.get('breakpoint_string', None)
+        if custom_string:
             return "{breakpoint_string}  # breakpoint {uid}{mark} noqa  //\n".format(
-            breakpoint_string=custom_string, uid=self.uid, mark='x' if self.in_block else '')
+                breakpoint_string=custom_string, uid=self.uid, mark='x' if self.in_block else '')
         return "{indent}import {dbg}; {dbg}.set_trace()  # breakpoint {uid}{mark} //\n".format(
             indent=' ' * indent, dbg=debugger, uid=self.uid, mark='x' if self.in_block else '')
 

--- a/PythonBreakpoints.py
+++ b/PythonBreakpoints.py
@@ -89,8 +89,9 @@ class Breakpoint(object):
         debugger = settings.get('debugger', 'pdb')
         custom_string = settings.get('breakpoint_string', None)
         if custom_string:
-            return "{breakpoint_string}  # breakpoint {uid}{mark} noqa  //\n".format(
-                breakpoint_string=custom_string, uid=self.uid, mark='x' if self.in_block else '')
+            return "{indent}{breakpoint_string}  # breakpoint {uid}{mark}  noqa  //\n".format(
+                indent=' ' * indent, breakpoint_string=custom_string,
+                uid=self.uid, mark='x' if self.in_block else '')
         return "{indent}import {dbg}; {dbg}.set_trace()  # breakpoint {uid}{mark} //\n".format(
             indent=' ' * indent, dbg=debugger, uid=self.uid, mark='x' if self.in_block else '')
 


### PR DESCRIPTION
I really like the tool, just wanted to add my own one liner

my users PythonBreakpoints.sublime-settings
```
{
"breakpoint_string": "print '-'*90; print locals(); print '-'*90; import ipdb; ipdb.set_trace()"
}

```

